### PR TITLE
Bag with more then one CKEditor textareas

### DIFF
--- a/mediaembed/plugin.js
+++ b/mediaembed/plugin.js
@@ -16,7 +16,7 @@
         init: function( editor )
         {
            var me = this;
-           CKEDITOR.dialog.add( 'MediaEmbedDialog', function ()
+           CKEDITOR.dialog.add( 'MediaEmbedDialog', function (instance)
            {
               return {
                  title : 'Embed Media',
@@ -45,8 +45,7 @@
                           var content = window.frames[i].document.getElementById("embed").value;
                        }
                     }
-                    console.log(this.getContentElement( 'iframe', 'embedArea' ).getValue());
-                    editor.insertHtml(this.getContentElement( 'iframe', 'embedArea' ).getValue());
+                    instance.insertHtml(this.getContentElement( 'iframe', 'embedArea' ).getValue());
                  }
               };
            } );
@@ -57,7 +56,8 @@
             {
                 label: 'Embed Media',
                 command: 'MediaEmbed',
-                icon: this.path + 'images/icon.png'
+                icon: this.path + 'images/icon.png',
+                toolbar: 'mediaembed'
             } );
         }
     } );


### PR DESCRIPTION
1. Fixed issue with more than one CKEditor fields in document. Before dialogs did insert html with embeded media only in one editor textarea.
2. Added toolbar setting for ui button
