### PR TITLE
Removed useless loop that triggers access violation errors in Firefox.

### DIFF
--- a/mediaembed/plugin.js
+++ b/mediaembed/plugin.js
@@ -42,13 +42,7 @@
                           }
                        ],
                   onOk: function() {
-                        for (var i = 0; i < window.frames.length; i++) {
-                            if (window.frames[i].name == 'iframeMediaEmbed') {
-                                var content = window.frames[i].document.getElementById("embed").value;
-                            }
-                        }
-                        // console.log(this.getContentElement( 'iframe', 'embedArea' ).getValue());
-                        div = instance.document.createElement('div');
+                        var div = instance.document.createElement('div');
                         div.setHtml(this.getContentElement('iframe', 'embedArea').getValue());
                         instance.insertElement(div);
                   }


### PR DESCRIPTION
This plugin was blundering through the window.frames array for no reason,
triggering access violation errors (and breaking) under certain conditions
in Firefox (see comments on http://ckeditor.com/addon/mediaembed). 
This patch should fix that.

Also added missing var so this plugin won't leak variables.
